### PR TITLE
0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.0] - Unreleased
+
+### Added
+- Managed: `:repo` option on `use Indexed.Managed` is now optional. Also,
+  specifying a module on the `managed` lines is optional. This means that
+  Managed can now work with non-`Ecto.Schema` maps, just like when using
+  Indexed directly. Some auto-discovery features may not be available, though.
+
+### Changed
+- Managed: `field` sort option is now `:datetime` instead of `:date_time`.
+
+
 ## [0.1.0] - 2022-11-30
 
-## Added
+### Added
 - Namespace mode: If an atom is passed to `use Indexed.Managed` in the
   `:namespace` option, then ETS tables for this instance of indexed will use
   named tables. This means that other processes can access the data directly as
@@ -19,7 +32,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
   auto-maintained for these fields such that `Indexed.get_by/4` can look up a
   list of IDs of records carrying a given value.
 
-## Changed
+### Changed
 - Properly exporting locals_without_parens in `.formatter.exs` so `managed`
   macro can be used without parens.
 - `Indexed.get_records/4` and `Indexed.get_uniques_list/4` now return an empty
@@ -28,10 +41,12 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Managed: Top-level keys in the `:managed_path` option will be auto-attached to
   the `:children` option.
 
-## Fixed
+### Fixed
 - Fixes around Paginator being an optional dependency.
 
+
 ## [0.0.1] - 2022-04-25
-## Added
+
+### Added
 
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2022-12-16
 
 ### Added
 - Managed: `:repo` option on `use Indexed.Managed` is now optional. Also,
   specifying a module on the `managed` lines is optional. This means that
   Managed can now work with non-`Ecto.Schema` maps, just like when using
   Indexed directly. Some auto-discovery features may not be available, though.
+- Prewarm ability on Indexed and Managed layers. This means a
+  `c:GenServer.init/1` can validate and initialize configuration, then create
+  the ETS tables, without inserting data. A `c:GenServer.handle_continue/2`
+  can then be used to do the heavy work of loading the data.
 
 ### Changed
 - Managed: `field` sort option is now `:datetime` instead of `:date_time`.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ cars = [
 ]
 
 # Sidenote: for date fields, instead of an atom (`:make`) use a tuple with the
-# sort option like `{:updated_at, sort: :date_time}`.
+# sort option like `{:updated_at, sort: :datetime}`.
 index =
   Indexed.warm(
     cars: [fields: [:make], data: cars]

--- a/lib/indexed.ex
+++ b/lib/indexed.ex
@@ -6,7 +6,7 @@ end
 
 defmodule Indexed do
   @moduledoc """
-  Tools for creating an index module.
+  Tools for creating an index.
   """
   alias Indexed.View
   alias __MODULE__
@@ -62,8 +62,9 @@ defmodule Indexed do
   """
   @type lookup :: %{any => [id]}
 
-  defdelegate prewarm(args), to: Indexed.Actions.Warm, as: :run
+  defdelegate prewarm(args), to: Indexed.Actions.Warm, as: :pre
   defdelegate warm(args), to: Indexed.Actions.Warm, as: :run
+  defdelegate warm(index, args), to: Indexed.Actions.Warm, as: :run
   defdelegate put(index, entity_name, record), to: Indexed.Actions.Put, as: :run
   defdelegate drop(index, entity_name, id), to: Indexed.Actions.Drop, as: :run
   defdelegate create_view(index, entity_name, fp, opts), to: Indexed.Actions.CreateView, as: :run

--- a/lib/indexed/actions/put.ex
+++ b/lib/indexed/actions/put.ex
@@ -287,7 +287,7 @@ defmodule Indexed.Actions.Put do
   def insert_by(put, old_desc_ids, {name, opts}) do
     find_fun =
       case opts[:sort] do
-        :date_time ->
+        :datetime ->
           fn id ->
             val = Map.get(Indexed.get(put.index, put.entity_name, id), name)
             :lt == DateTime.compare(val, Map.get(put.record, name))

--- a/lib/indexed/actions/warm.ex
+++ b/lib/indexed/actions/warm.ex
@@ -59,7 +59,7 @@ defmodule Indexed.Actions.Warm do
       sorted by field (atom) and direction (:asc or :desc), `t:data_tuple/0`.
     * `list` - data list with unknown ordering; must be sorted for every field.
   * `:fields` - List of field name atoms to index by. At least one required.
-    * If field is a DateTime, use sort: `{:my_field, sort: :date_time}`.
+    * If field is a DateTime, use sort: `{:my_field, sort: :datetime}`.
     * Ascending and descending will be indexed for each field.
   * `:id_key` - Primary key to use in indexes and for accessing the records of
     this entity.  See `t:Indexed.Entity.t/0`. Default: `:id`.
@@ -234,7 +234,7 @@ defmodule Indexed.Actions.Warm do
   @spec record_sort_fn(Entity.field()) :: (any, any -> boolean)
   def record_sort_fn({name, opts}) do
     case opts[:sort] do
-      :date_time -> &(:lt == DateTime.compare(Map.get(&1, name), Map.get(&2, name)))
+      :datetime -> &(:lt == DateTime.compare(Map.get(&1, name), Map.get(&2, name)))
       nil -> &(Map.get(&1, name) < Map.get(&2, name))
     end
   end

--- a/lib/indexed/actions/warm.ex
+++ b/lib/indexed/actions/warm.ex
@@ -35,7 +35,9 @@ defmodule Indexed.Actions.Warm do
   @type data_opt :: data_tuple | Indexed.record() | [Indexed.record()] | nil
 
   @doc """
-  For a set of entities, load data and indexes to ETS for each.
+  For a set of entities, "prewarm" the cache by validating and normalizing all
+  options and creating the ETS tables. Data and indexes will be created during
+  the main "warm" step which comes next.
 
   Argument is a keyword list where the top level has:
 
@@ -53,11 +55,6 @@ defmodule Indexed.Actions.Warm do
   as keys and keyword lists of options are values. Allowed options are as
   follows:
 
-  * `:data` - List of maps (with id key) -- the data to index and cache.
-    Required. May take one of the following forms:
-    * `{direction, field, list}` - data `list`, with a hint that it is already
-      sorted by field (atom) and direction (:asc or :desc), `t:data_tuple/0`.
-    * `list` - data list with unknown ordering; must be sorted for every field.
   * `:fields` - List of field name atoms to index by. At least one required.
     * If field is a DateTime, use sort: `{:my_field, sort: :datetime}`.
     * Ascending and descending will be indexed for each field.
@@ -83,50 +80,19 @@ defmodule Indexed.Actions.Warm do
       option as these are automatically included. These lists can be fetched
       via `get_uniques_list/4`.
   """
-  @spec run(keyword) :: Indexed.t()
-  def run(args \\ []) do
+  @spec pre(keyword) :: Indexed.t()
+  def pre(args \\ []) do
     ns = args[:namespace]
     ets_opts = Indexed.ets_opts(ns)
     index_ref = :ets.new(Indexed.table_name(ns), ets_opts)
 
     entities =
       Map.new(args[:entities] || args, fn {entity_name, opts} ->
-        ref =
-          ns
-          |> Indexed.table_name(entity_name)
-          |> :ets.new(ets_opts)
-
+        ref = :ets.new(Indexed.table_name(ns, entity_name), ets_opts)
         fields = resolve_fields_opt(opts[:fields], entity_name)
         id_key = opts[:id_key] || :id
         lookups = opts[:lookups] || []
         prefilter_configs = resolve_prefilters_opt(opts[:prefilters])
-
-        {_dir, _field, full_data} =
-          data_tuple = resolve_data_opt(opts[:data], entity_name, fields)
-
-        # Load the records into ETS, keyed by :id or the :id_key field.
-        Enum.each(full_data, &:ets.insert(ref, {id(&1, id_key), &1}))
-
-        warm = %Warm{
-          data_tuple: data_tuple,
-          entity_name: entity_name,
-          id_key: id_key,
-          index_ref: index_ref
-        }
-
-        Logger.debug("Warming #{entity_name}...")
-
-        # Create and insert the caches for this entity: for each prefilter
-        # configured, build & store indexes for each indexed field.
-        # Internally, a `t:prefilter/0` refers to a `{:my_field, "possible
-        # value"}` tuple or `nil` which we implicitly include, where no
-        # prefilter is applied.
-        for prefilter_config <- prefilter_configs,
-            do: warm_prefilter(warm, prefilter_config, fields)
-
-        # Create lookups: %{"Some Field Value" => [123, 456]}
-        for field_name <- lookups,
-            do: warm_lookups(warm, field_name)
 
         {entity_name,
          %Entity{
@@ -139,6 +105,62 @@ defmodule Indexed.Actions.Warm do
       end)
 
     %Indexed{entities: entities, index_ref: index_ref}
+  end
+
+  @doc """
+  See `pre/1`. The only difference is that the `:data` entity option is allowed:
+
+  * `:data` - List of maps (with id key) -- the data to index and cache.
+    Required. May take one of the following forms:
+    * `{direction, field, list}` - data `list`, with a hint that it is already
+      sorted by field (atom) and direction (:asc or :desc), `t:data_tuple/0`.
+    * `list` - data list with unknown ordering; must be sorted for every field.
+  """
+  @spec run(keyword) :: Indexed.t()
+  def run(args) do
+    do_run(pre(args), args)
+  end
+
+  @spec run(Indexed.t(), keyword) :: Indexed.t()
+  def run(index, args) do
+    do_run(index, args)
+  end
+
+  # Assuming prewarm is done, load the data.
+  @spec do_run(Indexed.t(), keyword) :: Indexed.t()
+  defp do_run(index, args) do
+    for {entity_name, opts} <- args[:entities] || args do
+      entity = Map.fetch!(index.entities, entity_name)
+
+      {_dir, _field, full_data} =
+        data_tuple = resolve_data_opt(opts[:data], entity_name, entity.fields)
+
+      # Load the records into ETS, keyed by :id or the :id_key field.
+      Enum.each(full_data, &:ets.insert(entity.ref, {id(&1, entity.id_key), &1}))
+
+      warm = %Warm{
+        data_tuple: data_tuple,
+        entity_name: entity_name,
+        id_key: entity.id_key,
+        index_ref: index.index_ref
+      }
+
+      Logger.debug("Warming #{entity_name}...")
+
+      # Create and insert the caches for this entity: for each prefilter
+      # configured, build & store indexes for each indexed field.
+      # Internally, a `t:prefilter/0` refers to a `{:my_field, "possible
+      # value"}` tuple or `nil` which we implicitly include, where no
+      # prefilter is applied.
+      for prefilter_config <- entity.prefilters,
+          do: warm_prefilter(warm, prefilter_config, entity.fields)
+
+      # Create lookups: %{"Some Field Value" => [123, 456]}
+      for field_name <- entity.lookups,
+          do: warm_lookups(warm, field_name)
+    end
+
+    index
   end
 
   # %{"Some Field Value" => [123, 456]}
@@ -173,7 +195,7 @@ defmodule Indexed.Actions.Warm do
     #{inspect(Enum.map(fields, &elem(&1, 0)))}\
     """)
 
-    if is_nil(pf_key) do
+    if nil == pf_key do
       Enum.each(fields, &warm_sorted.(nil, &1, full_data))
 
       # Store :maintain_unique fields on the nil prefilter. Other prefilters

--- a/lib/indexed/entity.ex
+++ b/lib/indexed/entity.ex
@@ -38,7 +38,7 @@ defmodule Indexed.Entity do
   ## Options
 
   * `:sort` - Indicates how the field should be sorted in ascending order:
-    * `:date_time` - `DateTime.compare/2` should be used for sorting.
+    * `:datetime` - `DateTime.compare/2` should be used for sorting.
     * `nil` (default) - `Enum.sort/1` will be used.
   """
   @type field :: {field_name, opts :: keyword}

--- a/lib/indexed/managed.ex
+++ b/lib/indexed/managed.ex
@@ -292,6 +292,8 @@ defmodule Indexed.Managed do
           @doc "Paginate records. See `Indexed.Actions.Paginate`."
           @spec paginate(atom, keyword) :: any
           def paginate(name, params \\ []), do: Managed.paginate(__MODULE__, name, params)
+
+          defoverridable paginate: 1, paginate: 2
         end
 
         defoverridable get: 2,
@@ -303,9 +305,7 @@ defmodule Indexed.Managed do
                        get_records: 1,
                        get_records: 2,
                        get_records: 3,
-                       get_records: 4,
-                       paginate: 1,
-                       paginate: 2
+                       get_records: 4
       end
 
       @doc "Create a Managed state struct, without index being initialized."

--- a/lib/indexed/managed/prepare.ex
+++ b/lib/indexed/managed/prepare.ex
@@ -111,7 +111,7 @@ defmodule Indexed.Managed.Prepare do
     end) || raise "No entity module #{mod} in #{inspect(Enum.map(manageds, & &1.module))}"
   end
 
-  @spec validate_before_compile!(module, module, list) :: :ok
+  @spec validate_before_compile!(module | nil, module, list) :: :ok
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
   def validate_before_compile!(mod, _repo, managed) do
     for %{children: _children, module: module, name: name, subscribe: sub, unsubscribe: unsub} <-
@@ -121,8 +121,8 @@ defmodule Indexed.Managed.Prepare do
       if (sub != nil and is_nil(unsub)) or (unsub != nil and is_nil(sub)),
         do: raise("Must have both :subscribe and :unsubscribe or neither #{inf}.")
 
-      function_exported?(module, :__schema__, 1) ||
-        raise "#{inspect(module)} should be an Ecto.Schema module #{inf}"
+      is_nil(mod) || is_atom(mod) ||
+        raise "#{inspect(module)} should be a struct module or nil #{inf}"
     end
 
     :ok

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Indexed.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/djthread/indexed"
-  @version "0.1.0"
+  @version "0.2.0"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Indexed.MixProject do
   use Mix.Project
 
-  @source_url "https://github.com/instinctscience/indexed"
+  @source_url "https://github.com/djthread/indexed"
   @version "0.1.0"
 
   def project do
@@ -31,8 +31,8 @@ defmodule Indexed.MixProject do
 
       # Docs
       name: "Indexed",
-      source_url: "https://github.com/instinctscience/indexed",
-      homepage_url: "https://github.com/instinctscience/indexed",
+      source_url: "https://github.com/djthread/indexed",
+      homepage_url: "https://github.com/djthread/indexed",
       docs: [
         main: "Indexed",
         extras: ["README.md"]

--- a/test/indexed/indexed_test.exs
+++ b/test/indexed/indexed_test.exs
@@ -274,4 +274,14 @@ defmodule IndexedTest do
 
     assert [%{id: 3}] = Indexed.lookup(index, :cars, :make, "Mazda")
   end
+
+  test "prewarm" do
+    index = Indexed.prewarm(cars: [fields: [:make]])
+
+    assert nil == Indexed.get(index, :cars, 1)
+
+    Indexed.warm(index, cars: [data: {:asc, :make, @cars}])
+
+    assert %Car{id: 1, make: "Lamborghini"} == Indexed.get(index, :cars, 1)
+  end
 end

--- a/test/indexed/indexed_test.exs
+++ b/test/indexed/indexed_test.exs
@@ -220,7 +220,7 @@ defmodule IndexedTest do
     index =
       Indexed.warm(
         cars: [
-          fields: [{:inserted_at, sort: :date_time}],
+          fields: [{:inserted_at, sort: :datetime}],
           data: cars
         ]
       )

--- a/test/indexed/managed_prewarm_test.exs
+++ b/test/indexed/managed_prewarm_test.exs
@@ -1,0 +1,31 @@
+defmodule Indexed.ManagedPrewarmTest do
+  use Indexed.TestCase
+  alias Indexed.Test.Repo
+
+  setup do
+    start_supervised!({Phoenix.PubSub, name: Blog})
+    :ok
+  end
+
+  defp paginate, do: BlogPrewarmingServer.paginate(:posts, order_by: [:inserted_at])
+  defp entries, do: paginate().entries
+
+  defp basic_setup do
+    Repo.insert!(%Post{content: "Hello World"})
+    Repo.insert!(%Post{content: "My post is the best."})
+
+    pid = start_supervised!(BlogPrewarmingServer.child_spec(feedback_pid: self()))
+
+    # GenServer.call to make sure it's done with its handle_continue.
+    :sys.get_state(pid)
+  end
+
+  test "basic" do
+    basic_setup()
+
+    assert [
+             %{content: "My post is the best."},
+             %{content: "Hello World"}
+           ] = entries()
+  end
+end

--- a/test/support/managed/blog_prewarming_server.ex
+++ b/test/support/managed/blog_prewarming_server.ex
@@ -1,0 +1,30 @@
+defmodule BlogPrewarmingServer do
+  @moduledoc """
+  Managed-using GenServer with a namespace (named ETS tables)
+  and prewarming only in init.
+  """
+  use GenServer
+  use Indexed.Managed, namespace: :blog, repo: Indexed.Test.Repo
+
+  managed :posts, Post, fields: [:inserted_at]
+
+  def call(msg), do: GenServer.call(__MODULE__, msg)
+  def run(fun), do: call({:run, fun})
+
+  def child_spec(opts \\ []) do
+    %{
+      id: __MODULE__,
+      start: {GenServer, :start_link, [__MODULE__, opts, [name: __MODULE__]]}
+    }
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, prewarm(), {:continue, :warm}}
+  end
+
+  @impl GenServer
+  def handle_continue(:warm, state) do
+    {:noreply, warm(state, :posts, Blog.all_posts())}
+  end
+end


### PR DESCRIPTION
```
## [0.2.0] - 2022-12-16

### Added
- Managed: `:repo` option on `use Indexed.Managed` is now optional. Also,
  specifying a module on the `managed` lines is optional. This means that
  Managed can now work with non-`Ecto.Schema` maps, just like when using
  Indexed directly. Some auto-discovery features may not be available, though.
- Prewarm ability on Indexed and Managed layers. This means a
  `c:GenServer.init/1` can validate and initialize configuration, then create
  the ETS tables, without inserting data. A `c:GenServer.handle_continue/2`
  can then be used to do the heavy work of loading the data.

### Changed
- Managed: `field` sort option is now `:datetime` instead of `:date_time`.
```