### PR TITLE
v0.4.0 unsorted mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic
 Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2023-02-27
+
+### Changed
+- `fields` list was optional, but the behavior when none declared has changed.
+  - Before, the `id_key` (default `:id`) was automatically used in the
+    background. This meant that presorted indexes (ascending and descending)
+    were auto-maintained and used as the default when calling `get_records` etc. 
+  - Now, no such presorted indexes will be maintained. When querying,
+    `:ets.tab_to_list/2` will be used, with no particular order being promised.
+
+## [0.3.3] - 2023-02-07
+
+### Changed
+- Minor dialyzer fix.
+
 ## [0.3.2] - 2023-02-03
 
 ### Added

--- a/lib/indexed/actions/create_view.ex
+++ b/lib/indexed/actions/create_view.ex
@@ -4,7 +4,6 @@ defmodule Indexed.Actions.CreateView do
   """
   alias Indexed.Actions.Warm
   alias Indexed.View
-  require Logger
 
   @typep id :: any
 
@@ -29,8 +28,6 @@ defmodule Indexed.Actions.CreateView do
   """
   @spec run(Indexed.t(), atom, View.fingerprint(), keyword) :: {:ok, View.t()} | :error
   def run(index, entity_name, fingerprint, opts \\ []) do
-    Logger.debug("Creating #{entity_name} view: #{fingerprint}")
-
     entity = Map.fetch!(index.entities, entity_name)
     prefilter = opts[:prefilter]
 
@@ -113,8 +110,6 @@ defmodule Indexed.Actions.CreateView do
       map_key = Indexed.uniques_map_key(entity_name, fingerprint, field_name)
       list_key = Indexed.uniques_list_key(entity_name, fingerprint, field_name)
 
-      Logger.debug("  * Saving #{field_name} uniques with #{map_size(counts_map)} values.")
-
       :ets.insert(index.index_ref, {map_key, counts_map})
       :ets.insert(index.index_ref, {list_key, list})
     end
@@ -140,8 +135,6 @@ defmodule Indexed.Actions.CreateView do
 
       asc_key = Indexed.index_key(entity_name, fingerprint, {:asc, field_name})
       desc_key = Indexed.index_key(entity_name, fingerprint, {:desc, field_name})
-
-      Logger.debug("  * Saving #{field_name} index with #{length(sorted_ids)} ids.")
 
       :ets.insert(index.index_ref, {asc_key, sorted_ids})
       :ets.insert(index.index_ref, {desc_key, Enum.reverse(sorted_ids)})

--- a/lib/indexed/entity.ex
+++ b/lib/indexed/entity.ex
@@ -4,7 +4,9 @@ defmodule Indexed.Entity do
 
   @typedoc """
   - `fields` : List of `t:field/0`s for which pairs of lists should be
-    maintained with the ID sorted ascending and descending.
+    maintained with the ID sorted ascending and descending. If none, then no
+    such indexes will be maintained and queries will default to
+    `order_hint: nil`, meaning that result ordering is not needed.
   - `id_key` : Specifies how to find the id for a record.  It can be an atom
     field name to access, a function, or a tuple in the form `{module,
     function_name}`. In the latter two cases, the record will be passed in.
@@ -20,16 +22,16 @@ defmodule Indexed.Entity do
       unique values under the prefilter will be managed. These lists can be
       fetched via `Indexed.get_uniques_list/4` and
       `Indexed.get_uniques_map/4`.
-  - `ref` : ETS table reference where records of this entity type are
-    stored, keyed by id. This will be nil in the version compiled into a managed
-    module.
+  - `ref` : ETS table reference where records of
+    this entity type are stored, keyed by id.
+    (`nil` in the instances compiled into a managed module.)
   """
   @type t :: %__MODULE__{
-          fields: [field],
+          fields: [field] | nil,
           id_key: any,
           lookups: [field_name],
           prefilters: [prefilter_config],
-          ref: :ets.tid() | atom | nil
+          ref: Indexed.table_ref() | nil
         }
 
   @typedoc """

--- a/lib/indexed/managed.ex
+++ b/lib/indexed/managed.ex
@@ -146,7 +146,7 @@ defmodule Indexed.Managed do
   """
   @type t :: %Managed{
           children: children,
-          fields: [atom | Entity.field()],
+          fields: [atom | Entity.field()] | nil,
           id_key: id_key,
           lookups: [Entity.field_name()],
           query: (Ecto.Queryable.t() -> Ecto.Queryable.t()) | nil,

--- a/lib/indexed/managed/prepare.ex
+++ b/lib/indexed/managed/prepare.ex
@@ -22,7 +22,6 @@ defmodule Indexed.Managed.Prepare do
     manageds
     |> map_put.(:children, &do_rewrite_children/2)
     |> map_put.(:prefilters, &do_rewrite_prefilters/2)
-    |> map_put.(:fields, &do_rewrite_fields/2)
     |> map_put.(:tracked, &do_rewrite_tracked/2)
   end
 
@@ -83,16 +82,6 @@ defmodule Indexed.Managed.Prepare do
       do: prefilters,
       else: finish.(required)
   end
-
-  # If :fields is empty, use the id key or the first field given by Ecto.
-  @spec do_rewrite_fields(Managed.t(), [Managed.t()]) :: [atom | Entity.field()]
-  defp do_rewrite_fields(%{fields: [], id_key: id_key}, _) when is_atom(id_key),
-    do: [id_key]
-
-  defp do_rewrite_fields(%{fields: [], module: mod}, _),
-    do: [hd(mod.__schema__(:fields))]
-
-  defp do_rewrite_fields(%{fields: fields}, _), do: fields
 
   # Return true for tracked if another entity has a :one association to us.
   @spec do_rewrite_tracked(Managed.t(), [Managed.t()]) :: boolean

--- a/lib/indexed/uniques_bundle.ex
+++ b/lib/indexed/uniques_bundle.ex
@@ -9,7 +9,6 @@ defmodule Indexed.UniquesBundle do
   of these values.
   """
   alias __MODULE__
-  require Logger
 
   @typedoc """
   A 3-element tuple defines unique values under a prefilter:
@@ -66,11 +65,6 @@ defmodule Indexed.UniquesBundle do
     map = Indexed.get_uniques_map(index, entity_name, prefilter, field_name)
     list = Indexed.get_uniques_list(index, entity_name, prefilter, field_name)
 
-    Logger.debug(fn ->
-      key = Indexed.uniques_map_key(entity_name, prefilter, field_name)
-      "UB: Getting #{key}: #{inspect(map)}"
-    end)
-
     {map, list, [], false}
   end
 
@@ -121,8 +115,6 @@ defmodule Indexed.UniquesBundle do
     field_pf? = is_tuple(prefilter)
 
     if not new? and field_pf? and Enum.empty?(list) do
-      Logger.debug("UB: Dropping #{counts_key}")
-
       # This prefilter has ran out of records -- delete the ETS table.
       # Note that for views (binary prefilter) and the global prefilter (nil)
       # we allow the uniques to remain in the empty state. They go when the
@@ -130,8 +122,6 @@ defmodule Indexed.UniquesBundle do
       :ets.delete(index_ref, list_key)
       :ets.delete(index_ref, counts_key)
     else
-      Logger.debug("UB: Putting #{counts_key}: #{inspect(counts_map)}")
-
       if new? or list_updated?,
         do: :ets.insert(index_ref, {list_key, list}),
         else: list

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Indexed.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/djthread/indexed"
-  @version "0.3.3"
+  @version "0.3.4"
 
   def project do
     [

--- a/test/indexed/indexed_test.exs
+++ b/test/indexed/indexed_test.exs
@@ -285,4 +285,24 @@ defmodule IndexedTest do
 
     assert %Car{id: 1, make: "Lamborghini"} == Indexed.get(index, :cars, 1)
   end
+
+  test "unsorted mode" do
+    index = Indexed.warm(cars: [data: @cars])
+
+    has? = fn makes ->
+      recs = Indexed.get_records(index, :cars)
+      Enum.all?(makes, fn m -> Enum.any?(recs, &(&1.make == m)) end)
+    end
+
+    assert has?.(~w(Lamborghini Mazda))
+
+    Indexed.put(index, :cars, %Car{id: 3, make: "Batmobile"})
+
+    assert has?.(~w(Lamborghini Mazda Batmobile))
+
+    Indexed.drop(index, :cars, 3)
+
+    refute has?.(~w(Batmobile))
+    assert has?.(~w(Lamborghini Mazda))
+  end
 end

--- a/test/support/managed/blog_server.ex
+++ b/test/support/managed/blog_server.ex
@@ -21,9 +21,9 @@ defmodule BlogServer do
     fields: [:inserted_at],
     manage_path: [author: :flare_pieces]
 
+  # No fields declared: Unsorted mode!
   managed :users, User,
     children: [:best_friend, :flare_pieces],
-    indexes: [:name],
     prefilters: [:name],
     subscribe: &Blog.subscribe_to_user/1,
     unsubscribe: &Blog.unsubscribe_from_user/1

--- a/test/support/managed/blog_server_nt.ex
+++ b/test/support/managed/blog_server_nt.ex
@@ -26,6 +26,7 @@ defmodule BlogServerNT do
     manage_path: [author: :flare_pieces]
 
   managed :users, User,
+    fields: [:id],
     children: [:best_friend, :flare_pieces],
     prefilters: [:name],
     lookups: [:name],


### PR DESCRIPTION
```
- `fields` list was optional, but the behavior when none declared has changed.
  * Before, the `id_key` (default `:id`) was automatically used in the
    background. This meant that presorted indexes (ascending and descending)
    were auto-maintained and used as the default when calling `get_records` etc. 
  * Now, no such presorted indexes will be maintained. When querying,
    `:ets.tab_to_list/2` will be used, with no particular order being promised.
```